### PR TITLE
property wrapper 를 구현해 중복코드 제거하기

### DIFF
--- a/iOS/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0EC21F4C5D33C39B97587978 /* Pods_Airbnb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CC1E133B9F1D8CF1859B8D0 /* Pods_Airbnb.framework */; };
 		33D6A8E53BA7E69CBCB5293A /* Pods_Airbnb_AirbnbUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8C1C869B0BC716E37E2003A /* Pods_Airbnb_AirbnbUITests.framework */; };
+		980C6CB3284FB48E0098D50C /* CodableLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980C6CB2284FB48E0098D50C /* CodableLayoutView.swift */; };
 		98113AB328488A42007412E2 /* RoomListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98113AB228488A42007412E2 /* RoomListUseCase.swift */; };
 		98113AB6284893F8007412E2 /* SearchResultRoomsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98113AB5284893F7007412E2 /* SearchResultRoomsHeaderView.swift */; };
 		98113AB828489428007412E2 /* SearchResultRoomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98113AB728489428007412E2 /* SearchResultRoomCell.swift */; };
@@ -92,6 +93,7 @@
 		3CC1E133B9F1D8CF1859B8D0 /* Pods_Airbnb.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Airbnb.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		54E47D54C555F8528176E246 /* Pods-AirbnbTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirbnbTests.release.xcconfig"; path = "Target Support Files/Pods-AirbnbTests/Pods-AirbnbTests.release.xcconfig"; sourceTree = "<group>"; };
 		961C633AEAC04338E9FA3D24 /* Pods-AirbnbTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirbnbTests.debug.xcconfig"; path = "Target Support Files/Pods-AirbnbTests/Pods-AirbnbTests.debug.xcconfig"; sourceTree = "<group>"; };
+		980C6CB2284FB48E0098D50C /* CodableLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableLayoutView.swift; sourceTree = "<group>"; };
 		98113AB228488A42007412E2 /* RoomListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListUseCase.swift; sourceTree = "<group>"; };
 		98113AB5284893F7007412E2 /* SearchResultRoomsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRoomsHeaderView.swift; sourceTree = "<group>"; };
 		98113AB728489428007412E2 /* SearchResultRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRoomCell.swift; sourceTree = "<group>"; };
@@ -266,7 +268,6 @@
 			isa = PBXGroup;
 			children = (
 				B55BF3CF28488A34009634F8 /* Reservation */,
-				98113AB128487E63007412E2 /* RoomSearch */,
 				B55A638E284705E900E08EE0 /* RoomPositionMap */,
 				982F765A2844C30E00DF8523 /* Server */,
 				982F76572844BDAA00DF8523 /* SearchFilter */,
@@ -337,6 +338,7 @@
 				B55A639B28477E9600E08EE0 /* CustomCollectionViewDataSource.swift */,
 				98B2756E2848F11D003BE859 /* Margins.swift */,
 				9874AA08284DA49A006D5D60 /* UIColor+Extension.swift */,
+				980C6CB2284FB48E0098D50C /* CodableLayoutView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -360,6 +362,26 @@
 				B55A6391284706B100E08EE0 /* RoomPositionMapUseCase.swift */,
 			);
 			path = RoomPositionMap;
+			sourceTree = "<group>";
+		};
+		B55BF3CF28488A34009634F8 /* Reservation */ = {
+			isa = PBXGroup;
+			children = (
+				B55BF3D228489045009634F8 /* Views */,
+				B55BF3D028488A43009634F8 /* ReservationViewController.swift */,
+			);
+			path = Reservation;
+			sourceTree = "<group>";
+		};
+		B55BF3D228489045009634F8 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B56FE196284DB5B9004CBE7A /* ReservationPriceTableViewCell.swift */,
+				B55BF3D5284892C4009634F8 /* ConditionLabel.swift */,
+				B55BF3D32848906F009634F8 /* ReservationConditionView.swift */,
+				B56FE194284DB341004CBE7A /* ReservationPriceView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		B55BF3D72848F67D009634F8 /* Resource */ = {
@@ -389,26 +411,6 @@
 				B55A639D2847C89E00E08EE0 /* CustomGoogleMapMarker.swift */,
 			);
 			path = View;
-			sourceTree = "<group>";
-		};
-		B55BF3CF28488A34009634F8 /* Reservation */ = {
-			isa = PBXGroup;
-			children = (
-				B55BF3D228489045009634F8 /* Views */,
-				B55BF3D028488A43009634F8 /* ReservationViewController.swift */,
-			);
-			path = Reservation;
-			sourceTree = "<group>";
-		};
-		B55BF3D228489045009634F8 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				B56FE196284DB5B9004CBE7A /* ReservationPriceTableViewCell.swift */,
-				B55BF3D5284892C4009634F8 /* ConditionLabel.swift */,
-				B55BF3D32848906F009634F8 /* ReservationConditionView.swift */,
-				B56FE194284DB341004CBE7A /* ReservationPriceView.swift */,
-			);
-			path = Views;
 			sourceTree = "<group>";
 		};
 		B576AE0B28406E6600B21D80 /* PositionSearch */ = {
@@ -748,6 +750,7 @@
 				9874AA09284DA49A006D5D60 /* UIColor+Extension.swift in Sources */,
 				B509353B283F68C50017C8E0 /* SearchFilterViewController.swift in Sources */,
 				B55A638D2845AC5B00E08EE0 /* SearchFilterUseCase.swift in Sources */,
+				980C6CB3284FB48E0098D50C /* CodableLayoutView.swift in Sources */,
 				982F76592844BE5900DF8523 /* RoomDetailViewController.swift in Sources */,
 				B5093546283FD50D0017C8E0 /* FilterCategory.swift in Sources */,
 				98F11303283F11B700009232 /* PositionSearchUseCase.swift in Sources */,
@@ -784,7 +787,7 @@
 				B56FE197284DB5B9004CBE7A /* ReservationPriceTableViewCell.swift in Sources */,
 				989934A42844F23300317A84 /* RoomDetail.swift in Sources */,
 				B55BF3D42848906F009634F8 /* ReservationConditionView.swift in Sources */,
-				B5093544283FD3F90017C8E0 /* ConditionSettingTableViewCell.swift in Sources */,
+				B5093544283FD3F90017C8E0 /* SearchFilterTableViewCell.swift in Sources */,
 				B5093544283FD3F90017C8E0 /* SearchFilterTableViewCell.swift in Sources */,
 				98B98E152847CAB800F76D11 /* RoomDetailHostProfileView.swift in Sources */,
 				B55BF3D128488A43009634F8 /* ReservationViewController.swift in Sources */,

--- a/iOS/Airbnb/Common/CodableLayoutView.swift
+++ b/iOS/Airbnb/Common/CodableLayoutView.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+@propertyWrapper
+struct CodableLayoutView<T: UIView> {
+    private var view: T
+    var wrappedValue: T {
+        get {
+            self.view.translatesAutoresizingMaskIntoConstraints = false
+            return view
+        }
+        set { view = newValue }
+    }
+    
+    init(view: T) {
+        self.view = view
+    }
+}

--- a/iOS/Airbnb/RoomList/RoomListViewController.swift
+++ b/iOS/Airbnb/RoomList/RoomListViewController.swift
@@ -19,7 +19,9 @@ class RoomListViewController: UIViewController {
     }
     
     // MARK: - Views
-    private let headerView = SearchResultRoomsHeaderView()
+    @CodableLayoutView(view: SearchResultRoomsHeaderView())
+    private var headerView: SearchResultRoomsHeaderView
+    
     
     private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -58,10 +60,8 @@ class RoomListViewController: UIViewController {
     
     // MARK: - private functions
     private func setupViews() {
-        view.addSubview(headerView)
-        headerView.translatesAutoresizingMaskIntoConstraints = false
-
         let safeAreaLayoutGuide = self.view.safeAreaLayoutGuide
+        view.addSubview(headerView)
         view.addSubview(collectionView)
         NSLayoutConstraint.activate([
             headerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Margins.top),
@@ -81,8 +81,6 @@ class RoomListViewController: UIViewController {
         ])
     }
 }
-
-
 
 
 // MARK: - UICollectionViewDataSource

--- a/iOS/Airbnb/RoomList/View/SearchResultRoomCell.swift
+++ b/iOS/Airbnb/RoomList/View/SearchResultRoomCell.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 final class SearchResultRoomCell: UICollectionViewCell {
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
@@ -20,6 +21,12 @@ final class SearchResultRoomCell: UICollectionViewCell {
         self.priceOneDayLabel.text = "₩\(pricePerDay) /박"
         self.totalPriceLabel.text = "총액 ₩\(totalPrice)"
     }
+
+    private let thumbnailImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .systemGray6
+        return imageView
+    }()
     
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -27,15 +34,7 @@ final class SearchResultRoomCell: UICollectionViewCell {
         label.font = .systemFont(ofSize: 20)
         label.numberOfLines = 1
         label.textColor = .airbnbGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
-    }()
-    
-    private let thumbnailImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.backgroundColor = .systemGray6
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
     }()
     
     private let reviewLabel: UILabel = {
@@ -43,7 +42,6 @@ final class SearchResultRoomCell: UICollectionViewCell {
         label.text = "0.0(후기 0개)"
         label.font = .systemFont(ofSize: 15, weight: .light)
         label.textColor = .airbnbGray3
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -52,7 +50,6 @@ final class SearchResultRoomCell: UICollectionViewCell {
         label.text = "₩ 0 /박"
         label.font = .boldSystemFont(ofSize: 18)
         label.textColor = .airbnbGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -61,7 +58,6 @@ final class SearchResultRoomCell: UICollectionViewCell {
         label.text = "총액 ₩"
         label.font = .systemFont(ofSize: 15, weight: .light)
         label.textColor = .airbnbGray3
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -71,22 +67,23 @@ final class SearchResultRoomCell: UICollectionViewCell {
         stackView.distribution = .fill
         stackView.alignment = .leading
         stackView.spacing = Margins.betweenLines
-        stackView.translatesAutoresizingMaskIntoConstraints = false
         
-        self.addSubview(stackView)
+        @CodableLayoutView(view: stackView) var layoutStackView
+        @CodableLayoutView(view: thumbnailImageView) var layoutThumbnailImageView
+        
+        self.addSubview(layoutStackView)
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            thumbnailImageView.widthAnchor.constraint(equalTo: self.widthAnchor)
+            layoutStackView.topAnchor.constraint(equalTo: topAnchor),
+            layoutStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            layoutStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            layoutStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            layoutThumbnailImageView.widthAnchor.constraint(equalTo: self.widthAnchor)
         ])
         
-        let thumbnailImageAutolayout = thumbnailImageView.heightAnchor.constraint(equalTo: thumbnailImageView.widthAnchor, multiplier: 0.7)
+        let thumbnailImageAutolayout = layoutThumbnailImageView.heightAnchor.constraint(equalTo: layoutThumbnailImageView.widthAnchor, multiplier: 0.7)
         thumbnailImageAutolayout.priority = .defaultLow
         thumbnailImageAutolayout.isActive = true
-        thumbnailImageView.clipsToBounds = true
-        thumbnailImageView.layer.cornerRadius = 10
+        layoutThumbnailImageView.clipsToBounds = true
+        layoutThumbnailImageView.layer.cornerRadius = 10
     }
 }

--- a/iOS/Airbnb/RoomList/View/SearchResultRoomsHeaderView.swift
+++ b/iOS/Airbnb/RoomList/View/SearchResultRoomsHeaderView.swift
@@ -10,6 +10,10 @@ final class SearchResultRoomsHeaderView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func updateView(with roomCount: Int) {
+        self.roomCountLabel.text = "\(roomCount)개 이상의 숙소"
+    }
+    
     private func setupViews() {
         let stackView = UIStackView(arrangedSubviews: [detailDescriptionLabel, roomCountLabel])
         stackView.axis = .vertical


### PR DESCRIPTION
### 문제점

코드로 뷰의 레이아웃을 잡기 위해 모든 view에

`translatesAutoresizingMaskIntoConstraints = false` 를 해 줘야 하는 문제가 있다.

```swift
let headerView = SearchResultRoomsHeaderView()
headerView.translatesAutoresizingMaskIntoConstraints = false
```
property wrapper 를 사용하면 이러한 중복코드를 한번 감싸서 숨길 수 있다.

property wrapper 의 정의는 아래처럼 할 수 있다:
```swift
@propertyWrapper
struct CodableLayoutView<T: UIView> {
    private var view: T = T()
    var wrappedValue: T {
        get {
            self.view.translatesAutoresizingMaskIntoConstraints = false
            return view
        }
        set { view = newValue }
    }
    init(view: T) {
        self.view = view
    }
}
```
이 property wrapper 를 이용하는 코드는 다음과 같다:
```swift
@LayoutCodable(view: stackView) var layoutStackView
self.addSubview(stackView)

NSLayoutConstraint.activate([
    layoutStackView.topAnchor.constraint(equalTo: topAnchor),
    layoutStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
    layoutStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
    layoutStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
])
```

### 고민
중복코드인 `myView.translatesAutoresizingMaskIntoConstraints = false` 를 줄이기 위해 사용 했습니다.
하지만 사실상 property wrapper 를 사용했을때나, 사용하지 않았을때나 같은 코드 한줄
- 적용 전 사용 코드: `myView.translatesAutoresizingMaskIntoConstraints = false`
- 적용 후 사용 코드: `@LayoutCodable(view: stackView) var layoutStackView`
로 처리가 가능하여 property wrapper 를 사용하는게 현재 상황에서 적합한가 궁금증이 일었습니다.
property wrapper 를 조금 더 효율적으로 사용하려면 어떻게 해야 할까요?